### PR TITLE
Race Condition

### DIFF
--- a/src/jvmMain/kotlin/edu.kit.iti.formal.flavium/WorkerQueue.kt
+++ b/src/jvmMain/kotlin/edu.kit.iti.formal.flavium/WorkerQueue.kt
@@ -121,8 +121,8 @@ class WorkerQueue(entries: List<Task> = listOf()) : Runnable {
             val task: Task? = queue.poll(60, TimeUnit.SECONDS)
             if (task != null) {
                 execute(task)
-                save()
             }
+            save()
         }
     }
 }

--- a/src/jvmMain/kotlin/edu.kit.iti.formal.flavium/WorkerQueue.kt
+++ b/src/jvmMain/kotlin/edu.kit.iti.formal.flavium/WorkerQueue.kt
@@ -59,7 +59,6 @@ class WorkerQueue(entries: List<Task> = listOf()) : Runnable {
     fun emit(javaCode: String): Pair<Task, Int> {
         val t = Task(UUID.randomUUID().toString(), "TODO", javaCode)
         queue.add(t)
-        save()
         return t to queue.size
     }
 


### PR DESCRIPTION
Wir haben aktuell noch ein Problem mit einer Race Condition:
- Wir fügen den Task in `WorkerQueue.emit` hinzu
- Dann passiert folgendes:
  - Wir speichern die Task Queue mit `save` (über die WorkerQueue Instanz synchronisiert) und erstellen hierfür zunächst mittels `toList` eine Liste der Queue
  - Wir pollen die queue mittels `queue.poll` (nicht synchronisiert)

Ab und zu passiert es, dass `toList` eine `java.util.NoSuchElementException` wirft.
Das liegt daran, dass die Funktion nicht Threadsafe zu sein scheint und nach der Fallunterscheidung 0 vs. 1 Element das Element bereits wieder herausgelöscht wurde.
Da wir das polling allerdings nicht synchronisieren wollen, hielte ich es für die beste Option einfach nur im Worker Thread zu speichern...