### PR TITLE
Fix leaderboard rank and queue position starting at zero

### DIFF
--- a/src/jvmMain/kotlin/edu.kit.iti.formal.flavium/Server.kt
+++ b/src/jvmMain/kotlin/edu.kit.iti.formal.flavium/Server.kt
@@ -155,7 +155,7 @@ private suspend fun PipelineContext<Unit, ApplicationCall>.submitController(tena
                         val pos = Jobs.select(
                             (Jobs.status eq -1) and
                                     (Jobs.rollingNumber less task.rollingNumber)
-                        ).count()
+                        ).count() + 1
                         task to pos
                     }
 

--- a/src/jvmMain/kotlin/edu.kit.iti.formal.flavium/pages.kt
+++ b/src/jvmMain/kotlin/edu.kit.iti.formal.flavium/pages.kt
@@ -154,7 +154,7 @@ class IndexPage(
 
                 leaderboardEntries.forEachIndexed { index, it ->
                     tr {
-                        td(classes = "right") { +"$index" }
+                        td(classes = "right") { +"${index + 1}" }
                         td { +it.pseudonym }
                         td(classes = "right") {
                             +"%3.3f".format(it.score)


### PR DESCRIPTION
The displayed rank in the leaderboard is currently starting at zero.
This pull request fixes this; with it, the rank is correctly displayed in the leaderboard and starts at one.